### PR TITLE
Add composer.json file for Composer & Satis compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "magmodules/magento1-channable",
+  "type": "magento-module",
+  "description": "Magento 1 Channable integration",
+  "version": "v1.5.3",
+  "keywords": [
+    "magento"
+  ],
+  "homepage": "https://github.com/magmodules/magento1-channable",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Magmodules"
+    }
+  ],
+  "require": {
+    "php": ">5.6.0"
+  }
+}


### PR DESCRIPTION
Note: if this is merged, a new release v1.5.4 must be made to allow Composer installation, the "version" in the `composer.json` file must always match the Git tagged version (including the v-prefix, if used).