### PR TITLE
Convert shipping prices from base currency to default current currency

### DIFF
--- a/app/code/community/Magmodules/Channable/Model/Channable.php
+++ b/app/code/community/Magmodules/Channable/Model/Channable.php
@@ -199,7 +199,27 @@ class Magmodules_Channable_Model_Channable extends Magmodules_Channable_Model_Co
         $config['field'] = $this->getFeedAttributes($storeId, $type, $config);
         $config['parent_att'] = $this->getParentAttributeSelection($config['field']);
 
+        foreach ($config['shipping_prices'] as &$shipping_price) {
+            if ($config['shipping_method'] !== 'weight') {
+                $shipping_price['price_from'] = $this->convertToCurrency($shipping_price['price_from'], $config['base_currency_code'], $config['currency']);
+                $shipping_price['price_to'] = $this->convertToCurrency($shipping_price['price_to'], $config['base_currency_code'], $config['currency']);
+            }
+            $shipping_price['cost'] = $this->convertToCurrency($shipping_price['cost'], $config['base_currency_code'], $config['currency']);
+        }
+
         return $config;
+    }
+
+    /**
+     * @param string|float $price
+     * @param string $baseCurrency
+     * @param string $currency
+     *
+     * @return float
+     */
+    private function convertToCurrency($price, $baseCurrency, $currency)
+    {
+        return Mage::helper('directory')->currencyConvert($price, $baseCurrency, $currency);
     }
 
     /**

--- a/app/code/community/Magmodules/Channable/Model/Channable.php
+++ b/app/code/community/Magmodules/Channable/Model/Channable.php
@@ -199,12 +199,15 @@ class Magmodules_Channable_Model_Channable extends Magmodules_Channable_Model_Co
         $config['field'] = $this->getFeedAttributes($storeId, $type, $config);
         $config['parent_att'] = $this->getParentAttributeSelection($config['field']);
 
-        foreach ($config['shipping_prices'] as &$shipping_price) {
-            if ($config['shipping_method'] !== 'weight') {
-                $shipping_price['price_from'] = $this->convertToCurrency($shipping_price['price_from'], $config['base_currency_code'], $config['currency']);
-                $shipping_price['price_to'] = $this->convertToCurrency($shipping_price['price_to'], $config['base_currency_code'], $config['currency']);
+        // Convert prices form base currency to default currency
+        if ($this->helper->getConfigData('advanced/shipping_convert_prices', $storeId)) {
+            foreach ($config['shipping_prices'] as &$shipping_price) {
+                if ($config['shipping_method'] !== 'weight') {
+                    $shipping_price['price_from'] = $this->convertToCurrency($shipping_price['price_from'], $config['base_currency_code'], $config['currency']);
+                    $shipping_price['price_to'] = $this->convertToCurrency($shipping_price['price_to'], $config['base_currency_code'], $config['currency']);
+                }
+                $shipping_price['cost'] = $this->convertToCurrency($shipping_price['cost'], $config['base_currency_code'], $config['currency']);
             }
-            $shipping_price['cost'] = $this->convertToCurrency($shipping_price['cost'], $config['base_currency_code'], $config['currency']);
         }
 
         return $config;

--- a/app/code/community/Magmodules/Channable/etc/config.xml
+++ b/app/code/community/Magmodules/Channable/etc/config.xml
@@ -119,6 +119,9 @@
                 <stock_status>1</stock_status>
                 <stock>1</stock>
             </data>
+            <advanced>
+                <shipping_convert_prices>0</shipping_convert_prices>
+            </advanced>
             <server>
                 <memory_limit>1024M</memory_limit>
                 <max_execution_time>300</max_execution_time>

--- a/app/code/community/Magmodules/Channable/etc/system.xml
+++ b/app/code/community/Magmodules/Channable/etc/system.xml
@@ -556,11 +556,21 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </shipping_method>
+                        <shipping_convert_prices translate="label">
+                            <label>Shipping Convert Prices</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>52</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Convert shipping prices from, to and cost from base currency to default currency.]]></comment>
+                        </shipping_convert_prices>
                         <shipping_price>
                             <label>The Shipping Price</label>
                             <frontend_model>channable/adminhtml_config_form_field_shipping</frontend_model>
                             <backend_model>channable/adminhtml_system_config_backend_design_shipping</backend_model>
-                            <sort_order>52</sort_order>
+                            <sort_order>53</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>


### PR DESCRIPTION
Converted the config shipping prices from base currency to default currency.

We've got a shop that has EURO as a base currency. But for the British website we use GBP as the default currency. This is correctly picked up by the feed, but the shipping prices then also need to be filled in as the GPB price. But in the shipping method table rates we fill in the prices with EUR and they get converted to the selected currency of the customer, in this case EUR or GPB.

So from our point of view if your base currency is EUR, then all the prices you use in the backend of Magento should be EUR. In the feed you suffix with the Default Currency. In that case you should also use the currency converted method provided by Magento.

This doesn't have major impact on your feed because we added system configuration that is disabled by default. This solves the issue that the conversion rate changes every night and that your shipping costs are different by a couple of cents, compared to table rates or another shipping method. 